### PR TITLE
Changes to Support Roblox Studio's Dark Theme

### DIFF
--- a/src/ScrollingFrame.lua
+++ b/src/ScrollingFrame.lua
@@ -292,7 +292,6 @@ function ScrollingFrame:AddScrollbarFromContainer(Container)
 	local ScrollBar = Instance.new("ImageButton")
 	ScrollBar.Size = UDim2.new(1, 0, 0, 100)
 	ScrollBar.Name = "ScrollBar"
-	ScrollBar.BackgroundColor3 = Color3.new(0.8, 0.8, 0.8)
 	ScrollBar.BorderSizePixel = 0
 	ScrollBar.Image = ""
 	ScrollBar.Parent = Container

--- a/src/ThemeSwitcher.lua
+++ b/src/ThemeSwitcher.lua
@@ -1,0 +1,141 @@
+-- Theme Switcher for Quenty's Class Converter Plugin
+-- provides support for Roblox Studio's Themes
+-- defaults to light theme if Roblox Studio ever supports more themes
+-- @author presssssure
+
+local ThemeSwitcher = {}
+
+local Studio = settings().Studio
+
+local DockWidget = nil
+
+local LightColors = {
+	Background = Color3.fromRGB(255, 255, 255),
+	BackgroundOnHover = Color3.fromRGB(242, 242, 242),
+
+	Text = Color3.fromRGB(40, 40, 40),
+	DropDownText = Color3.fromRGB(27, 42, 53),
+	DropDownAccent = Color3.fromRGB(0, 0, 0),
+	TextBoxText = Color3.fromRGB(49, 49, 49),
+
+	Line = Color3.fromRGB(230, 230, 230),
+	ScrollBar = Color3.fromRGB(230, 230, 230),
+	ScrollBarOnHover = Color3.fromRGB(161, 161, 161),
+	Selected = Color3.fromRGB(90, 142, 243),
+
+	ButtonStyle = Enum.ButtonStyle.RobloxRoundDropdownButton,
+}
+local DarkColors = {
+	Background = Color3.fromRGB(46, 46, 46),
+	BackgroundOnHover = Color3.fromRGB(56, 56, 56),
+
+	Text = Color3.fromRGB(204, 204, 204),
+	DropDownText = Color3.fromRGB(191, 206, 217),
+	DropDownAccent = Color3.fromRGB(255, 255, 255),
+	TextBoxText = Color3.fromRGB(213, 213, 213),
+
+	Line = Color3.fromRGB(21, 21, 21),
+	ScrollBar = Color3.fromRGB(76, 76, 76),
+	ScrollBarOnHover = Color3.fromRGB(96, 96, 96),
+	Selected = Color3.fromRGB(90, 142, 243),
+
+	ButtonStyle = Enum.ButtonStyle.RobloxButton,
+}
+local ConvertButtonTextColor = Color3.fromRGB(255, 255, 255)
+
+
+-- find theme colors (defaults to light if other themes are available besides light and dark)
+local function GetColorPalette(theme)
+	if theme == Enum.UITheme.Dark then
+		return DarkColors
+	end
+	return LightColors
+end
+
+
+-- determines if a button is a button in the dropdown menu
+local function isInDropDown(obj)
+	return (obj.Parent.Parent.Parent.Parent and obj.Parent.Parent.Parent.Parent.Name == "DropDown")
+end
+
+
+-- determines if something is a "Line" (really skinny Frame that stretches across the page)
+local function isLine(obj)
+	return obj.AbsoluteSize.Y == 1 or obj.AbsoluteSize.Y == 2
+end
+
+
+-- changes the theme of a given ui element
+function ThemeSwitcher.SwitchObject(obj, theme)
+	if not obj:IsA("GuiBase") then return end
+	theme = theme or Studio["UI Theme"]
+
+	local NewPalette = GetColorPalette(theme)
+
+	-- handle special cases first
+	if isLine(obj) then -- lines in the main view
+		obj.BackgroundColor3 = NewPalette.Line
+		return
+	elseif obj.Name == "Scrollbar" then -- scroll bar in the drop down
+		obj.BackgroundColor3 = NewPalette.ScrollBar
+		return
+	elseif obj.Name == "CheckButton" then -- check boxes in the main view
+		obj.Style = NewPalette.ButtonStyle
+		-- no return on purpose, text color still needs to be changed
+	elseif obj.Name == "ConvertButton" then -- ConvertButton's text color is always the same
+		obj.TextColor3 = ConvertButtonTextColor
+		return
+	end
+
+	-- then change the text
+	if obj.ClassName:find("Text") then
+		local NewTextColor
+
+		if obj:IsA("TextBox") then
+			 NewTextColor = NewPalette.TextBoxText
+		elseif isInDropDown(obj) then
+			NewTextColor = NewPalette.DropDownText
+		else
+			NewTextColor = NewPalette.Text
+		end
+
+		obj.TextColor3 = NewTextColor
+	end
+
+	-- lastly change the background
+	obj.BackgroundColor3 = NewPalette.Background
+end
+
+
+-- switches every ui element within
+local function SwitchAllObjects(NewTheme)
+	for _, obj in pairs(DockWidget:GetDescendants()) do
+		ThemeSwitcher.SwitchObject(obj, NewTheme)
+	end
+end
+
+
+-- for when the user changes theme while having the window open
+Studio.ThemeChanged:Connect(function()
+	SwitchAllObjects(Studio["UI Theme"])
+end)
+
+
+-- switches the plugin dock widget and all the objects within it
+function ThemeSwitcher.SetDockWidget(NewDockWidget)
+	DockWidget = NewDockWidget
+
+	SwitchAllObjects(Studio["UI Theme"])
+	DockWidget.DescendantAdded:Connect(function(obj)
+		ThemeSwitcher.SwitchObject(obj, Studio["UI Theme"])
+	end)
+end
+
+
+-- allow other scripts to access colors
+function ThemeSwitcher.GetColorFor(ElementString)
+	local Palette = GetColorPalette(Studio["UI Theme"])
+	return Palette[ElementString]
+end
+
+return ThemeSwitcher

--- a/src/ThemeSwitcher.lua
+++ b/src/ThemeSwitcher.lua
@@ -15,7 +15,7 @@ local LightColors = {
 
 	Text = Color3.fromRGB(40, 40, 40),
 	DropDownText = Color3.fromRGB(27, 42, 53),
-	DropDownAccent = Color3.fromRGB(0, 0, 0),
+	DropDownMouseOverLerp = Color3.fromRGB(0, 0, 0),
 	TextBoxText = Color3.fromRGB(49, 49, 49),
 
 	Line = Color3.fromRGB(230, 230, 230),
@@ -31,7 +31,7 @@ local DarkColors = {
 
 	Text = Color3.fromRGB(204, 204, 204),
 	DropDownText = Color3.fromRGB(191, 206, 217),
-	DropDownAccent = Color3.fromRGB(255, 255, 255),
+	DropDownMouseOverLerp = Color3.fromRGB(255, 255, 255),
 	TextBoxText = Color3.fromRGB(213, 213, 213),
 
 	Line = Color3.fromRGB(21, 21, 21),

--- a/src/UI.lua
+++ b/src/UI.lua
@@ -198,7 +198,7 @@ function DropDownButton:UpdateRender()
 	end
 
 	if self.MouseOver then
-		Desired = Desired:lerp(ThemeSwitcher.GetColorFor("DropDownAccent"), 0.05)
+		Desired = Desired:lerp(ThemeSwitcher.GetColorFor("DropDownMouseOverLerp"), 0.05)
 	end
 
 	self.Gui.BackgroundColor3 = Desired

--- a/src/UI.lua
+++ b/src/UI.lua
@@ -3,6 +3,7 @@ local Signal = require(script.Parent:WaitForChild("Signal"))
 local ScrollingFrame = require(script.Parent:WaitForChild("ScrollingFrame"))
 local ValueObject = require(script.Parent:WaitForChild("ValueObject"))
 local IconHandler = require(script.Parent:WaitForChild("IconHandler"))
+local ThemeSwitcher = require(script.Parent:WaitForChild("ThemeSwitcher"))
 local HttpService = game:GetService("HttpService")
 
 local function TrimString(str, pattern)
@@ -191,13 +192,13 @@ function DropDownButton:GetData()
 end
 
 function DropDownButton:UpdateRender()
-	local Desired = Color3.new(1, 1, 1)
+	local Desired = ThemeSwitcher.GetColorFor("Background")
 	if self.IsSelected.Value then
-		Desired = Color3.new(90/255, 142/255, 243/255)
+		Desired = ThemeSwitcher.GetColorFor("Selected")
 	end
 
 	if self.MouseOver then
-		Desired = Desired:lerp(Color3.new(0, 0, 0), 0.05)
+		Desired = Desired:lerp(ThemeSwitcher.GetColorFor("DropDownAccent"), 0.05)
 	end
 
 	self.Gui.BackgroundColor3 = Desired
@@ -330,9 +331,9 @@ end
 
 function DropDownFilter:UpdateRender()
 	if self.MouseOver then
-		self.Background.BackgroundColor3 = Color3.new(0.95, 0.95, 0.95)
+		self.Background.BackgroundColor3 = ThemeSwitcher.GetColorFor("BackgroundOnHover")
 	else
-		self.Background.BackgroundColor3 = Color3.new(1, 1, 1)
+		self.Background.BackgroundColor3 = ThemeSwitcher.GetColorFor("Background")
 	end
 
 	if not self.Gui:IsFocused() then

--- a/src/init.server.lua
+++ b/src/init.server.lua
@@ -17,6 +17,7 @@ end
 local Converter = require(script:WaitForChild("Converter"))
 local UI = require(script:WaitForChild("UI"))
 local Signal = require(script:WaitForChild("Signal"))
+local ThemeSwitcher = require(script:WaitForChild("ThemeSwitcher"))
 
 local Selection do
 	if not IS_DEBUG_MODE then
@@ -107,6 +108,7 @@ do
 			240
 		)
 		screenGui = plugin:CreateDockWidgetPluginGui("Quenty_Class_Converter", info)
+		ThemeSwitcher.SetDockWidget(screenGui)
 		screenGui.Title = "Quenty's Class Converter Plugin"
 	end
 	screenGui:BindToClose(function()


### PR DESCRIPTION
Added some code to support Roblox's built in dark theme. Most of the changes are contained in a new script, "ThemeSwitcher". The only things I've changed in other scripts were lines that directly set the color of certain UI elements. If they were still needed they now call a function in ThemeSwitcher to get the correct color of the object they need to change. If needed in the future, it should be relatively easy to make new themes for the plugin.

Dark Theme Examples:
Main page:
![main](https://user-images.githubusercontent.com/33643911/67721064-09771100-f9ac-11e9-8ea3-e36cefd4fd8e.png)
Dropdown menu:
![dropdown](https://user-images.githubusercontent.com/33643911/67721126-2ca1c080-f9ac-11e9-8bcb-e5980e2ac4bd.png)

Switching between light and dark theme:
![switching](https://cdn.discordapp.com/attachments/510610831692529681/638498009868664843/I1fq07OgUa.gif)

Edit: This adds a feature mentioned in #5.